### PR TITLE
Updated from version 4.2.7 (without ‘add store for mobile application…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7173,61 +7173,6 @@
         }
       }
     },
-    "remap-istanbul": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.9.6.tgz",
-      "integrity": "sha512-l0WDBsVjaTzP8m3glERJO6bjlAFUahcgfcgvcX+owZw7dKeDLT3CVRpS7UO4L9LfGcMiNsqk223HopwVxlh8Hg==",
-      "requires": {
-        "amdefine": "1.0.1",
-        "gulp-util": "3.0.7",
-        "istanbul": "0.4.5",
-        "minimatch": "3.0.4",
-        "source-map": "0.6.1",
-        "through2": "2.0.1"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
-          "requires": {
-            "readable-stream": "2.0.6",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "remap-istanbul": "^0.9.6",
     "reselect": "^3.0.1",
     "uuid": "^3.2.1"
   },
@@ -35,8 +34,7 @@
     "pretest": "npm run build -- --source-maps='inline'",
     "build": "babel ./src -d ./lib",
     "watch": "npm run build -- -w",
-    "flow": "flow",
-    "cover-src": "npm test && remap-istanbul -i coverage/coverage.json -o coverage/html-report -t html"
+    "flow": "flow"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…s’ that used “react-navigation-redux-helpers”) and removing “remap-istanbul” implementation.  [Basically removing the 2 “Level-3” dependency pkgs: ‘react-navigation-redux-helpers’ & ‘remap-istanbul’]